### PR TITLE
feat: ls settings override.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,45 @@ Zed extension for the
 
 ![Harper in the Zed Extension Gallery](./images/extension_in_gallery.png)
 
+## Configuration
+
+The extension is configured via the `lsp` section of your zed settings.
+Addition info can be found [here](https://github.com/elijah-potter/harper/tree/master/harper-ls).
+```json
+"lsp": {
+  "harper-ls": {
+    "settings": {
+      "harper-ls": {
+        "userDictPath": "~/dict.txt",
+        "fileDictPath": "~/.harper/",
+        "diagnosticSeverity": "hint", // hint, warning, error, information
+        "linters": {
+          "spell_check": true,
+          "spelled_numbers": true,
+          "an_a": true,
+          "sentence_capitalization": true,
+          "unclosed_quotes": true,
+          "wrong_quotes": false,
+          "long_sentences": true,
+          "repeated_words": true,
+          "spaces": true,
+          "matcher": true,
+          "correct_number_suffix": true,
+          "number_suffix_capitalization": true,
+          "multiple_sequential_pronouns": true,
+          "linking_verbs": false,
+          "avoid_curses": true,
+          "terminating_conjunctions": true
+        },
+        codeActions = {
+          forceStable = false // Force code actions to appear in "stable" positions
+        }
+      }
+    }
+  }
+},
+```
+
 ## Acknowledgments
 
 - [elijah-potter](https://github.com/elijah-potter) for creating Harper

--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "harper"
 name = "harper"
-version = "0.0.4"
+version = "0.0.5"
 schema_version = 1
 authors = ["Stef Robbe <stef.robbe@protonmail.com>"]
 description = "Harper LS support"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 use std::fs;
 use std::path::PathBuf;
-use zed_extension_api::{self as zed, Result};
+use zed_extension_api::{self as zed, settings::LspSettings, Result};
 
 struct HarperExtension {
     binary_cache: Option<PathBuf>,
@@ -139,6 +139,18 @@ impl zed::Extension for HarperExtension {
         Self::new()
     }
 
+    fn language_server_initialization_options(
+        &mut self,
+        server_id: &zed_extension_api::LanguageServerId,
+        worktree: &zed_extension_api::Worktree,
+    ) -> Result<Option<zed_extension_api::serde_json::Value>> {
+        let settings = LspSettings::for_worktree(server_id.as_ref(), worktree)
+            .ok()
+            .and_then(|lsp_settings| lsp_settings.initialization_options.clone())
+            .unwrap_or_default();
+        Ok(Some(settings))
+    }
+
     fn language_server_command(
         &mut self,
         language_server_id: &zed::LanguageServerId,
@@ -154,6 +166,18 @@ impl zed::Extension for HarperExtension {
             args: vec!["--stdio".to_string()],
             env: binary.env.unwrap_or_default(),
         })
+    }
+
+    fn language_server_workspace_configuration(
+        &mut self,
+        server_id: &zed_extension_api::LanguageServerId,
+        worktree: &zed_extension_api::Worktree,
+    ) -> Result<Option<zed_extension_api::serde_json::Value>> {
+        let settings = LspSettings::for_worktree(server_id.as_ref(), worktree)
+            .ok()
+            .and_then(|lsp_settings| lsp_settings.settings.clone())
+            .unwrap_or_default();
+        Ok(Some(settings))
     }
 }
 


### PR DESCRIPTION
implements #3 

add basic settings support.
update readme to show configuration.
bump version to 0.0.5

usage:
```json
"lsp": {
  "harper-ls": {
    "settings": {
      "harper-ls": {
        "userDictPath": "~/dict.txt",
        "fileDictPath": "~/.harper/",
        "diagnosticSeverity": "hint", // hint, warning, error, information
        "linters": {
          "spell_check": true,
          "spelled_numbers": true,
          "an_a": true,
          "sentence_capitalization": true,
          "unclosed_quotes": true,
          "wrong_quotes": false,
          "long_sentences": true,
          "repeated_words": true,
          "spaces": true,
          "matcher": true,
          "correct_number_suffix": true,
          "number_suffix_capitalization": true,
          "multiple_sequential_pronouns": true,
          "linking_verbs": false,
          "avoid_curses": true,
          "terminating_conjunctions": true
        },
        codeActions = {
          forceStable = false // Force code actions to appear in "stable" positions
        }
      }
    }
  }
},
```