### PR TITLE
fix: Use new GitHub repository URL for `harper` binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Harper Zed Extension
 
 Zed extension for the
-[Harper Grammar Checker](https://github.com/elijah-potter/harper) LS.
+[Harper Grammar Checker](https://github.com/Automattic/harper) LS.
 
 ![Harper running inside zed](./images/zed_demo.png)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ impl HarperExtension {
         );
 
         let release = zed::latest_github_release(
-            "elijah-potter/harper",
+            "Automattic/harper",
             zed::GithubReleaseOptions {
                 require_assets: true,
                 pre_release: false,


### PR DESCRIPTION
Technically no difference, but good for future-proofing the extension in case something happens with the GitHub redirect from `elijah-potter/harper` to `Automattic/harper`.